### PR TITLE
Enabled Simulated Traffic

### DIFF
--- a/EDWW/Settings/RG Berlin Settings/Settings TOWER/GENERAL.txt
+++ b/EDWW/Settings/RG Berlin Settings/Settings TOWER/GENERAL.txt
@@ -4,7 +4,7 @@ m_ShowAirspaceLines:0
 m_ShowRouteFixName:1
 m_ShowRouteETA:1
 m_ShowCalculatedHeading:1
-m_ShowSimulatedData:0
+m_ShowSimulatedData:1
 m_TransitionAltitude:5500
 m_AllowConcernedACTagDown:0
 m_CenterlineDme:0.4


### PR DESCRIPTION
Für Tower profile, um die Gate Zuweisung bereits vorher synchronisiert zu bekommen. 